### PR TITLE
後編: 自分以外のユーザーの一覧をトップページに表示する

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,6 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @users = User.all
+    @users = User.where.not(id: current_user.id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,6 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @interviews = Interview.all
     @users = User.all
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  enum sex: { male: 0, female: 1, others: 2 }
+  enum sex: { 男性: 0, 女性: 1, その他: 2 }
   has_many :interviews, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-  enum sex: { 男性: 0, 女性: 1, その他: 2 }
+  enum sex: { male: 0, female: 1, others: 2 }
   has_many :interviews, dependent: :destroy
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,11 +28,11 @@
   <div class="field form-group">
     <%= f.label :sex %><br />
     <%= f.label :male %>
-    <%= f.radio_button :sex, :男性 %>
+    <%= f.radio_button :sex, :male %>
     <%= f.label :female %>
-    <%= f.radio_button :sex, :女性 %>
+    <%= f.radio_button :sex, :female %>
     <%= f.label :others %>
-    <%= f.radio_button :sex, :その他 %>
+    <%= f.radio_button :sex, :others %>
   </div>
 
   <div class="field form-group">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,11 +28,11 @@
   <div class="field form-group">
     <%= f.label :sex %><br />
     <%= f.label :male %>
-    <%= f.radio_button :sex, :male, autocomplete: "male" %>
+    <%= f.radio_button :sex, :男性 %>
     <%= f.label :female %>
-    <%= f.radio_button :sex, :female, autocomplete: "female" %>
+    <%= f.radio_button :sex, :女性 %>
     <%= f.label :others %>
-    <%= f.radio_button :sex, :others, autocomplete: "others" %>
+    <%= f.radio_button :sex, :その他 %>
   </div>
 
   <div class="field form-group">

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -14,7 +14,7 @@
   <tbody>
     <% @interviews.each do |interview| %>
       <tr>
-        <td><%= interview.candidate.strftime("%Y年%m月%d日 %H時%M分") %></td>
+        <td><%= interview.candidate.to_s(:datetime) %></td>
         <td><%= interview.approval %></td>
         <td><%= link_to '編集', edit_interview_path(interview), class: "btn btn-warning" %></td>
         <td><%= link_to '削除', interview, method: :delete, data: { confirm: '本当に削除してよろしいですか?' } ,class: "btn btn-danger" %></td>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -14,7 +14,7 @@
   <tbody>
     <% @interviews.each do |interview| %>
       <tr>
-        <td><%= interview.candidate %></td>
+        <td><%= interview.candidate.strftime("%Y年%m月%d日 %H時%M分") %></td>
         <td><%= interview.approval %></td>
         <td><%= link_to '編集', edit_interview_path(interview), class: "btn btn-warning" %></td>
         <td><%= link_to '削除', interview, method: :delete, data: { confirm: '本当に削除してよろしいですか?' } ,class: "btn btn-danger" %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,4 @@
 <h1>ユーザー一覧</h1>
-<p>※一覧は後半で作成するため表示内容は仮です。</p>
 <table class="table table-bordered">
   <thead>
     <tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -24,7 +24,7 @@
     </td>
     <td>
     <% if user.sex? %>
-      <%= t "enum.sex.#{user.sex}" %>
+      <%= t "model.user.sex.#{user.sex}" %>
     <% elsif %>
       性別が未登録です。
     <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -25,7 +25,7 @@
     </td>
     <td><%= user.sex %></td>
     <td><%= user.school %></td>
-    <td><%= Interview.find(user.id).candidate.strftime("%Y年%m月%d日 %H時%M分") rescue nil %></td>
+    <td><%= Interview.where(approval: '承認').find_by(user_id: user.id).candidate.strftime("%Y年%m月%d日 %H時%M分") rescue nil %></td>
     <td class="text-center"><a href="#" class="btn btn-primary">面接一覧</a></td>
   </tr>
   <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,19 +3,23 @@
 <table class="table table-bordered">
   <thead>
     <tr>
-      <td>名前</td>
-      <td>Email</td>
-      <td>年齢</td>
-      <td>面接日時</td>
-      <td>面接一覧</td>
+      <th>名前</th>
+      <th>Email</th>
+      <th>年齢</th>
+      <th>性別</th>
+      <th>学校名</th>
+      <th>面接日時</th>
+      <th>面接一覧</th>
     </tr>
   </thead>
-  <% @interviews.each do |interview| %>
+  <% @users.each do |user| %>
   <tr>
-    <td><%= User.find(interview.user_id).name %></td>
-    <td><%= User.find(interview.user_id).email %></td>
+    <td><%= user.name %></td>
+    <td><%= user.email %></td>
     <td>※年齢が入ります※</td>
-    <td><%= interview.candidate %></td>
+    <td><%= user.sex %></td>
+    <td><%= user.school %></td>
+    <td><%= Interview.find(user.id).candidate %></td>
     <td>※面接一覧へのリンクが入ります※</td>
   </tr>
   <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,7 +16,13 @@
   <tr>
     <td><%= user.name %></td>
     <td><%= user.email %></td>
-    <td>※年齢が入ります※</td>
+    <td>
+    <% if user.birthday? %>
+      <%= (Time.zone.now.year) - (user.birthday.year) %>才
+    <% elsif %>
+      誕生日を登録してください。
+    <% end %>
+    </td>
     <td><%= user.sex %></td>
     <td><%= user.school %></td>
     <td><%= Interview.find(user.id).candidate %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -31,7 +31,7 @@
     <% end %>
     </td>
     <td><%= user.school %></td>
-    <td><%= Interview.where(approval: '承認').find_by(user_id: user.id).candidate.strftime("%Y年%m月%d日 %H時%M分") rescue nil %></td>
+    <td><%= Interview.where(approval: '承認').find_by(user_id: user.id).candidate.to_s(:datetime) rescue nil %></td>
     <td class="text-center"><a href="#" class="btn btn-primary">面接一覧</a></td>
   </tr>
   <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,13 +20,13 @@
     <% if user.birthday? %>
       <%= (Time.zone.now.year) - (user.birthday.year) %>才
     <% elsif %>
-      誕生日を登録してください。
+      生年月日が未登録です。
     <% end %>
     </td>
     <td><%= user.sex %></td>
     <td><%= user.school %></td>
-    <td><%= Interview.find(user.id).candidate rescue nil %></td>
-    <td>※面接一覧へのリンクが入ります※</td>
+    <td><%= Interview.find(user.id).candidate.strftime("%Y年%m月%d日 %H時%M分") rescue nil %></td>
+    <td class="text-center"><a href="#" class="btn btn-primary">面接一覧</a></td>
   </tr>
   <% end %>
 </table>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,7 +23,13 @@
       生年月日が未登録です。
     <% end %>
     </td>
-    <td><%= user.sex %></td>
+    <td>
+    <% if user.sex? %>
+      <%= t "enum.sex.#{user.sex}" %>
+    <% elsif %>
+      性別が未登録です。
+    <% end %>
+    </td>
     <td><%= user.school %></td>
     <td><%= Interview.where(approval: '承認').find_by(user_id: user.id).candidate.strftime("%Y年%m月%d日 %H時%M分") rescue nil %></td>
     <td class="text-center"><a href="#" class="btn btn-primary">面接一覧</a></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,7 +30,7 @@
     <% end %>
     </td>
     <td><%= user.school %></td>
-    <td><%= Interview.where(approval: '承認').find_by(user_id: user.id).candidate.to_s(:datetime) rescue nil %></td>
+    <td><%= Interview.where(approval: '承認').find_by(user_id: user.id)&.candidate&.to_s(:datetime) %></td>
     <td class="text-center"><a href="#" class="btn btn-primary">面接一覧</a></td>
   </tr>
   <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -25,7 +25,7 @@
     </td>
     <td><%= user.sex %></td>
     <td><%= user.school %></td>
-    <td><%= Interview.find(user.id).candidate %></td>
+    <td><%= Interview.find(user.id).candidate rescue nil %></td>
     <td>※面接一覧へのリンクが入ります※</td>
   </tr>
   <% end %>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:datetime] = "%Y年%m月%d日 %H時%M分"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -203,3 +203,8 @@ ja:
       long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       short: "%y/%m/%d %H:%M"
     pm: 午後
+  enum:
+    sex:
+      female: "女性"
+      male: "男性"
+      others: "その他"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -203,8 +203,9 @@ ja:
       long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       short: "%y/%m/%d %H:%M"
     pm: 午後
-  enum:
-    sex:
-      female: "女性"
-      male: "男性"
-      others: "その他"
+  model:
+    user:
+      sex:
+        female: "女性"
+        male: "男性"
+        others: "その他"


### PR DESCRIPTION
# 概要

- サンプルアプリ後編
- 第2章 第1節 自分以外のユーザーの一覧をトップページに表示する

## やりたかったこと

- 自分以外のユーザー一覧をトップページに表示する

## やったこと

- ログイン中のユーザー以外のユーザー一覧を呼び出す
- 年齢を表示する
- approvalが「承認」の面接日程のみを表示する
（承認状態の変更画面は次の節で実装予定のため、コンソール上でデータを変えています。）
- 面接一覧のボタンを設定する
（リンク先とページの作成は次の節で実装予定です。）

## 動作確認方法
- アプリケーションのURLにアクセスする
  https://e-navigator-chinats.herokuapp.com/
- ログインする
  メールアドレス: user1@feedforce.jp または suzuki@xx.xx
  パスワード: password
- 自分以外のユーザー一覧が表示されていることを確認する

## その他
気になっている点をコメントしますので、併せてみていただけるとありがたいです。