### PR TITLE
後編: 面談日程を承認or拒否できるようにする

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -48,12 +48,8 @@ class InterviewsController < ApplicationController
        end
     else
       @interview.approved!
-      if @interview.approval == 'approved'
-        @user.interviews.where.not(id: @interview.id).update_all(approval:2)
-        redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
-      else
-        render :index
-      end
+      @user.interviews.where.not(id: @interview.id).update_all(approval:2)
+      redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
     end
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -6,16 +6,6 @@ class InterviewsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
     @interviews = @user.interviews
-    def update
-      @user = User.find(params[:user_id])
-      Interview.where(user_id: @user.id).update_all(approval:'却下')
-      @interview.approval = "承認"
-      if @interview.save
-        redirect_to user_interview_path, notice: '日程が更新されました。'
-      else
-        render :index
-      end
-    end
   end
 
   # GET /users/:id/interviews/1
@@ -48,15 +38,25 @@ class InterviewsController < ApplicationController
 
   # PATCH/PUT /users/:id/interviews/1
   def update
-    @interview.user = current_user
-    if @interview.update(interview_params)
-      redirect_to user_interview_path, notice: '面接日程が更新されました。'
+    @user = User.find(params[:user_id])
+    if @user == current_user
+       @interview.user = current_user
+       if @interview.save
+         redirect_to user_interview_path, notice: '面接日程が更新されました。'
+       else
+         render :index
+       end
     else
-      render :edit
+      Interview.where(user_id: @user.id).update_all(approval:'却下')
+      @interview.approval = "承認"
+      if @interview.save
+        redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
+      else
+        render :index
+      end
     end
   end
 
-  # DELETE /users/:id/interviews/1
   def destroy
     @interview.destroy
     redirect_to user_interviews_url, notice: '面接日程が削除されました。'

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -7,7 +7,7 @@ class InterviewsController < ApplicationController
     @user = User.find(params[:user_id])
     @interviews = @user.interviews
     def update
-      Interview.find(params[:user_id]).approval = "却下"
+      Interview.where(approval: '承認').find(params[:user_id]).approval = "却下"
       @interview.approval = "承認"
       if @interview.save
         redirect_to user_interview_path, notice: '日程が更新されました。'
@@ -69,6 +69,6 @@ class InterviewsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def interview_params
-      params.permit(:candidate, :approval)
+      params.require(:interview).permit(:candidate, :approval)
     end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -48,8 +48,8 @@ class InterviewsController < ApplicationController
        end
     else
       Interview.where(user_id: @user.id).update_all(approval:'却下')
-      @interview.approval = "承認"
       if @interview.save
+        Interview.where(id: @interview.id).update(approval:'承認')
         redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
       else
         render :index

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -40,11 +40,11 @@ class InterviewsController < ApplicationController
   def update
     @user = User.find(params[:user_id])
     if @user == current_user
-       if @interview.update(interview_params)
-         @interview.pending!
-         redirect_to user_interview_path, notice: '面接日程が更新されました。'
-       else
-         render :edit
+      if @interview.update(interview_params)
+        @interview.pending!
+        redirect_to user_interview_path, notice: '面接日程が更新されました。'
+      else
+        render :edit
        end
     else
       @interview.approved!

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -7,7 +7,8 @@ class InterviewsController < ApplicationController
     @user = User.find(params[:user_id])
     @interviews = @user.interviews
     def update
-      Interview.where(approval: '承認').find(params[:user_id]).approval = "却下"
+      @user = User.find(params[:user_id])
+      Interview.where(user_id: @user.id).update_all(approval:'却下')
       @interview.approval = "承認"
       if @interview.save
         redirect_to user_interview_path, notice: '日程が更新されました。'

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -41,7 +41,7 @@ class InterviewsController < ApplicationController
     @user = User.find(params[:user_id])
     if @user == current_user
        if @interview.update(interview_params)
-         @interview.update_attributes(approval:0)
+         @interview.pending!
          redirect_to user_interview_path, notice: '面接日程が更新されました。'
        else
          render :edit
@@ -49,7 +49,7 @@ class InterviewsController < ApplicationController
     else
       if @interview.save
         Interview.where(user_id: @user.id).update_all(approval:0)
-        Interview.where(id: @interview.id).update(approval:1)
+        @interview.approved!
         redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
       else
         render :index

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -6,6 +6,14 @@ class InterviewsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
     @interviews = @user.interviews
+    def update
+      @interview.approval = "承認"
+      if @interview.save
+        redirect_to user_interview_path, notice: '日程が更新されました。'
+      else
+        render :index
+      end
+    end
   end
 
   # GET /users/:id/interviews/1

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -47,8 +47,8 @@ class InterviewsController < ApplicationController
          render :edit
        end
     else
-      Interview.where(user_id: @user.id).update_all(approval:'却下')
       if @interview.save
+        Interview.where(user_id: @user.id).update_all(approval:'却下')
         Interview.where(id: @interview.id).update(approval:'承認')
         redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
       else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -7,6 +7,7 @@ class InterviewsController < ApplicationController
     @user = User.find(params[:user_id])
     @interviews = @user.interviews
     def update
+      Interview.find(params[:user_id]).approval = "却下"
       @interview.approval = "承認"
       if @interview.save
         redirect_to user_interview_path, notice: '日程が更新されました。'
@@ -68,6 +69,6 @@ class InterviewsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def interview_params
-      params.require(:interview).permit(:candidate, :approval)
+      params.permit(:candidate, :approval)
     end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -57,6 +57,7 @@ class InterviewsController < ApplicationController
     end
   end
 
+  # DELETE /users/:id/interviews/1
   def destroy
     @interview.destroy
     redirect_to user_interviews_url, notice: '面接日程が削除されました。'

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -41,15 +41,15 @@ class InterviewsController < ApplicationController
     @user = User.find(params[:user_id])
     if @user == current_user
        if @interview.update(interview_params)
-         @interview.update_attributes(approval:'保留')
+         @interview.update_attributes(approval:0)
          redirect_to user_interview_path, notice: '面接日程が更新されました。'
        else
          render :edit
        end
     else
       if @interview.save
-        Interview.where(user_id: @user.id).update_all(approval:'却下')
-        Interview.where(id: @interview.id).update(approval:'承認')
+        Interview.where(user_id: @user.id).update_all(approval:0)
+        Interview.where(id: @interview.id).update(approval:1)
         redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
       else
         render :index

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -47,9 +47,8 @@ class InterviewsController < ApplicationController
          render :edit
        end
     else
-      #@interview.approval = 1
       @interview.approved!
-      if @interview.save
+      if @interview.approval == 'approved'
         @user.interviews.where.not(id: @interview.id).update_all(approval:2)
         redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
       else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -47,8 +47,9 @@ class InterviewsController < ApplicationController
          render :edit
        end
     else
-      if @interview.update(interview_params)
+      if @interview.save
         @user.interviews.where.not(id: @interview.id).update_all(approval:2)
+        @interview.approved!
         redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
       else
         render :index

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -40,7 +40,8 @@ class InterviewsController < ApplicationController
   def update
     @user = User.find(params[:user_id])
     if @user == current_user
-       if @interview.save
+       if @interview.update(interview_params)
+         @interview.update_attributes(approval:'保留')
          redirect_to user_interview_path, notice: '面接日程が更新されました。'
        else
          render :edit

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -48,7 +48,7 @@ class InterviewsController < ApplicationController
        end
     else
       @interview.approved!
-      @user.interviews.where.not(id: @interview.id).update_all(approval:2)
+      @user.interviews.where.not(id: @interview.id).update_all(approval: :rejected)
       redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
     end
   end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -40,7 +40,6 @@ class InterviewsController < ApplicationController
   def update
     @user = User.find(params[:user_id])
     if @user == current_user
-       @interview.user = current_user
        if @interview.save
          redirect_to user_interview_path, notice: '面接日程が更新されました。'
        else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -44,7 +44,7 @@ class InterviewsController < ApplicationController
        if @interview.save
          redirect_to user_interview_path, notice: '面接日程が更新されました。'
        else
-         render :index
+         render :edit
        end
     else
       Interview.where(user_id: @user.id).update_all(approval:'却下')

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -47,9 +47,8 @@ class InterviewsController < ApplicationController
          render :edit
        end
     else
-      if @interview.save
-        Interview.where(user_id: @user.id).update_all(approval:0)
-        @interview.approved!
+      if @interview.update(interview_params)
+        @user.interviews.where.not(id: @interview.id).update_all(approval:2)
         redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
       else
         render :index

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -47,9 +47,10 @@ class InterviewsController < ApplicationController
          render :edit
        end
     else
+      #@interview.approval = 1
+      @interview.approved!
       if @interview.save
         @user.interviews.where.not(id: @interview.id).update_all(approval:2)
-        @interview.approved!
         redirect_to user_interview_path, notice: '承認面接日程が更新されました。'
       else
         render :index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,5 @@ class UsersController < ApplicationController
 
   def index
     @users = User.where.not(id: current_user.id)
-    @interviews = Interview.all
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,5 +3,6 @@ class UsersController < ApplicationController
 
   def index
     @users = User.where.not(id: current_user.id)
+    @interviews = Interview.all
   end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,3 +1,4 @@
 class Interview < ApplicationRecord
   belongs_to :user
+  validates :candidate, presence: true
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,4 +1,5 @@
 class Interview < ApplicationRecord
   belongs_to :user
   validates :candidate, presence: true
+  enum approval: { pending: 0, approval: 1, rejected: 2 }
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,5 +1,5 @@
 class Interview < ApplicationRecord
   belongs_to :user
   validates :candidate, presence: true
-  enum approval: { pending: 0, approval: 1, rejected: 2 }
+  enum approval: { pending: 0, approved: 1, rejected: 2 }
 end

--- a/app/views/interviews/_interviewer_index.html.erb
+++ b/app/views/interviews/_interviewer_index.html.erb
@@ -11,13 +11,16 @@
   </div>
   <hr>
   <p>面接日程を変更する場合は以下から選んでください。</p>
-  <form>
-    <ul class="sw-List_plane">
-      <% @interviews.each do |interview| %>
-        <li class="sw-mt10"><input type="button" class="btn btn-default btn-block" value="<%= interview.candidate.to_s(:datetime) %>"></input></li>
-      <% end %>
-    </ul>
-  </form>
+  <ul class="sw-List_plane">
+    <% @interviews.each do |interview| %>
+      <li class="sw-mt10">
+        <%= form_for([@user, interview]) do |f| %>
+          <%= f.submit(interview.candidate.to_s(:datetime),
+          data: { confirm: interview.candidate.to_s(:datetime)+'で面接を確定していいですか？' }, class: "btn btn-default btn-block") %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
 <% end %>
 <ul class="sw-List_plane">
   <li><%= link_to '戻る', root_path %></li>

--- a/app/views/interviews/_interviewer_index.html.erb
+++ b/app/views/interviews/_interviewer_index.html.erb
@@ -15,6 +15,7 @@
     <% @interviews.each do |interview| %>
       <li class="sw-mt10">
         <%= form_for([@user, interview]) do |f| %>
+          <%= f.hidden_field :approval, {value: 'approved'} %>
           <%= f.submit(interview.candidate.to_s(:datetime),
           data: { confirm: interview.candidate.to_s(:datetime)+'で面接を確定していいですか？' }, class: "btn btn-default btn-block") %>
         <% end %>

--- a/app/views/interviews/_interviewer_index.html.erb
+++ b/app/views/interviews/_interviewer_index.html.erb
@@ -5,7 +5,7 @@
   <div>
     <h2>現在の面接日程</h2>
     <p>
-      <strong><%= Interview.where(approval: '承認').find_by(user_id: @user.id)&.candidate&.to_s(:datetime) %></strong>
+      <strong><%= Interview.where(approval:1).find_by(user_id: @user.id)&.candidate&.to_s(:datetime) %></strong>
       に面接が設定されています。
     </p>
   </div>

--- a/app/views/interviews/_interviewer_index.html.erb
+++ b/app/views/interviews/_interviewer_index.html.erb
@@ -15,7 +15,6 @@
     <% @interviews.each do |interview| %>
       <li class="sw-mt10">
         <%= form_for([@user, interview]) do |f| %>
-          <%= f.hidden_field :approval, {value: 'approved'} %>
           <%= f.submit(interview.candidate.to_s(:datetime),
           data: { confirm: interview.candidate.to_s(:datetime)+'で面接を確定していいですか？' }, class: "btn btn-default btn-block") %>
         <% end %>

--- a/app/views/interviews/_interviewer_index.html.erb
+++ b/app/views/interviews/_interviewer_index.html.erb
@@ -5,7 +5,7 @@
   <div>
     <h2>現在の面接日程</h2>
     <p>
-      <strong><%= Interview.where(approval:1).find_by(user_id: @user.id)&.candidate&.to_s(:datetime) %></strong>
+      <strong><%= Interview.approved.find_by(user_id: @user.id)&.candidate&.to_s(:datetime) %></strong>
       に面接が設定されています。
     </p>
   </div>

--- a/app/views/interviews/_user_index.html.erb
+++ b/app/views/interviews/_user_index.html.erb
@@ -14,7 +14,7 @@
       <% @interviews.each do |interview| %>
         <tr>
           <td><%= interview&.candidate&.to_s(:datetime) %></td>
-          <td><%= interview.approval %></td>
+          <td><%= t "model.interview.approval.#{interview.approval}" %></td>
           <td><%= link_to '編集', edit_user_interview_path(@user, interview), class: "btn btn-warning" %></td>
           <td><%= link_to '削除', user_interview_url(@user, interview), method: :delete, data: { confirm: '本当に削除してよろしいですか?' } ,class: "btn btn-danger" %></td>
         </tr>

--- a/app/views/interviews/_user_index.html.erb
+++ b/app/views/interviews/_user_index.html.erb
@@ -13,7 +13,7 @@
     <tbody>
       <% @interviews.each do |interview| %>
         <tr>
-          <td><%= interview.candidate.to_s(:datetime) rescue nil %></td>
+          <td><<%= interview&.candidate&.to_s(:datetime) %></td>
           <td><%= interview.approval %></td>
           <td><%= link_to '編集', edit_user_interview_path(@user, interview), class: "btn btn-warning" %></td>
           <td><%= link_to '削除', user_interview_url(@user, interview), method: :delete, data: { confirm: '本当に削除してよろしいですか?' } ,class: "btn btn-danger" %></td>

--- a/app/views/interviews/_user_index.html.erb
+++ b/app/views/interviews/_user_index.html.erb
@@ -13,7 +13,7 @@
     <tbody>
       <% @interviews.each do |interview| %>
         <tr>
-          <td><<%= interview&.candidate&.to_s(:datetime) %></td>
+          <td><%= interview&.candidate&.to_s(:datetime) %></td>
           <td><%= interview.approval %></td>
           <td><%= link_to '編集', edit_user_interview_path(@user, interview), class: "btn btn-warning" %></td>
           <td><%= link_to '削除', user_interview_url(@user, interview), method: :delete, data: { confirm: '本当に削除してよろしいですか?' } ,class: "btn btn-danger" %></td>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <% if @user == current_user %>
   <%= render 'user_index' %>
 <% else %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,4 +1,3 @@
-<p id="notice"><%= notice %></p>
 <p>
   <strong>面接日程:</strong>
   <%= @interview.candidate %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -5,7 +5,7 @@
 </p>
 <p>
   <strong>承認状態:</strong>
-  <%= @interview.approval %>
+  <%= t "model.interview.approval.#{@interview.approval}" %>
 </p>
 <%= link_to '編集する', edit_user_interview_path(@user, @interview) %>
 <%= link_to '戻る', root_path %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -24,7 +24,7 @@
       </td>
       <td>
         <% if user.sex? %>
-          <%= t "enum.sex.#{user.sex}" %>
+          <%= t "model.user.sex.#{user.sex}" %>
         <% elsif %>
           性別が未登録です。
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,7 +30,7 @@
         <% end %>
       </td>
       <td><%= user.school %></td>
-      <td><%= Interview.where(approval: '承認').find_by(user_id: user.id)&.candidate&.to_s(:datetime) %></td>
+      <td><%= Interview.where(approval:1).find_by(user_id: user.id)&.candidate&.to_s(:datetime) %></td>
       <td class="text-center"><%= link_to '面接一覧', user_interviews_path(user), class: "btn btn-primary" %></td>
     </tr>
   <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,7 +30,7 @@
         <% end %>
       </td>
       <td><%= user.school %></td>
-      <td><%= Interview.where(approval:1).find_by(user_id: user.id)&.candidate&.to_s(:datetime) %></td>
+      <td><%= Interview.approved.find_by(user_id: user.id)&.candidate&.to_s(:datetime) %></td>
       <td class="text-center"><%= link_to '面接一覧', user_interviews_path(user), class: "btn btn-primary" %></td>
     </tr>
   <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -212,5 +212,5 @@ ja:
     interview:
       approval:
         pending: "保留"
-        approval: "承認"
+        approved: "承認"
         rejected: "却下"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -209,3 +209,8 @@ ja:
         female: "女性"
         male: "男性"
         others: "その他"
+    interview:
+      approval:
+        pending: "保留"
+        approval: "承認"
+        rejected: "却下"

--- a/db/migrate/20180324060208_create_interviews.rb
+++ b/db/migrate/20180324060208_create_interviews.rb
@@ -2,7 +2,7 @@ class CreateInterviews < ActiveRecord::Migration[5.1]
   def change
     create_table :interviews do |t|
       t.datetime :candidate
-      t.string :approval, default: "保留"
+      t.integer :approval, default: 0
       t.string :user_id
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 20180324060208) do
 
   create_table "interviews", force: :cascade do |t|
     t.datetime "candidate"
-    t.string "approval", default: "保留"
+    t.integer "approval", default: 0
     t.string "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# 概要
サンプルアプリ後編
第2章 第3節 面談日程を承認or拒否できるようにする

# やりたかったこと
面接官用の一覧ページから日程を承認する。承認した日程以外は却下する。

# やったこと
- 面接官用の一覧ページから日程を承認する
- 承認した日程以外は却下する
- 面接日程を作成する際に、日程が空であればバリデーションでエラーにする

# 動作確認方法
## ページへのアクセス
アプリケーションのURLにアクセスする
https://e-navigator-chinats.herokuapp.com/
## ログインする
メールアドレス: user1@feedforce.jp
パスワード: password
## 承認機能の確認
ユーザー一覧の「面接一覧」より承認する日程を選択する。
承認後に他の日程を承認し、承認した日程以外が却下になることを確認する。
## バリデーション
自分の面接一覧より「新しい面接日程を登録する」を選択、日付を入力せずに「登録する」を選択する。

# その他
承認した以外の日程を却下する機能について、controllerとformの書き方に迷いました。アドバイスなどありましたら、コメントいただけるとありがたいです。
